### PR TITLE
feat(design-system): migrate Separator to react-aria-components

### DIFF
--- a/frontend/design-system/src/components/Separator/Separator.tsx
+++ b/frontend/design-system/src/components/Separator/Separator.tsx
@@ -1,22 +1,41 @@
 import * as React from 'react'
+import { Separator as AriaSeparator } from 'react-aria-components'
 
 import { cn } from '../../utils/cn'
 
-type SeparatorProps = React.ComponentProps<'div'> & {
+type SeparatorProps = {
+  className?: string
   orientation?: 'horizontal' | 'vertical'
   decorative?: boolean
-}
+} & Omit<React.ComponentProps<'div'>, 'role'>
 
-export const Separator = ({ className, orientation = 'horizontal', decorative = true, ...props }: SeparatorProps) => (
-  <div
-    data-slot="separator"
-    role={decorative ? 'none' : 'separator'}
-    aria-orientation={!decorative ? orientation : undefined}
-    data-orientation={orientation}
-    className={cn(
-      'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
-      className
-    )}
-    {...props}
-  />
-)
+export const Separator = ({ className, orientation = 'horizontal', decorative = true, ...props }: SeparatorProps) => {
+  if (decorative) {
+    return (
+      <div
+        data-slot="separator"
+        role="none"
+        data-orientation={orientation}
+        className={cn(
+          'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+
+  return (
+    <AriaSeparator
+      elementType="div"
+      orientation={orientation}
+      data-slot="separator"
+      data-orientation={orientation}
+      className={cn(
+        'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        className
+      )}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

- `decorative=true` (default): plain `<div role="none">` — RAC always sets `role="separator"` so decorative case bypasses it
- `decorative=false`: uses `AriaSeparator elementType="div"` — RAC handles `role="separator"` and `aria-orientation` automatically
- Zero test changes required

## Breaking changes

None.

## Test plan

- [x] 8/8 unit tests pass with zero modifications

🤖 Generated with [Claude Code](https://claude.ai/claude-code)